### PR TITLE
Pass the metadata to the openai call

### DIFF
--- a/lib/langchain/assistant.rb
+++ b/lib/langchain/assistant.rb
@@ -47,6 +47,7 @@ module Langchain
       # Callbacks
       add_message_callback: nil,
       tool_execution_callback: nil,
+      metadata: nil,
       &block
     )
       unless tools.is_a?(Array) && tools.all? { |tool| tool.class.singleton_class.included_modules.include?(Langchain::ToolDefinition) }
@@ -70,6 +71,8 @@ module Langchain
       @total_prompt_tokens = 0
       @total_completion_tokens = 0
       @total_tokens = 0
+
+      @metadata = metadata
     end
 
     # Add a user message to the messages array
@@ -343,7 +346,8 @@ module Langchain
         messages: array_of_message_hashes,
         tools: @tools,
         tool_choice: tool_choice,
-        parallel_tool_calls: parallel_tool_calls
+        parallel_tool_calls: parallel_tool_calls,
+        metadata: @metadata
       )
       @llm.chat(**params, &@block)
     end

--- a/lib/langchain/assistant/llm/adapters/anthropic.rb
+++ b/lib/langchain/assistant/llm/adapters/anthropic.rb
@@ -18,9 +18,11 @@ module Langchain
             instructions:,
             tools:,
             tool_choice:,
-            parallel_tool_calls:
+            parallel_tool_calls:,
+            metadata: nil
           )
             params = {messages: messages}
+            params[:metadata] = metadata if metadata
             if tools.any?
               params[:tools] = build_tools(tools)
               params[:tool_choice] = build_tool_choice(tool_choice, parallel_tool_calls)

--- a/lib/langchain/assistant/llm/adapters/google_gemini.rb
+++ b/lib/langchain/assistant/llm/adapters/google_gemini.rb
@@ -18,11 +18,14 @@ module Langchain
             instructions:,
             tools:,
             tool_choice:,
-            parallel_tool_calls:
+            parallel_tool_calls:,
+            metadata: nil
           )
             Langchain.logger.warn "WARNING: `parallel_tool_calls:` is not supported by Google Gemini currently"
 
             params = {messages: messages}
+            params[:metadata] = metadata if metadata
+
             if tools.any?
               params[:tools] = build_tools(tools)
               params[:system] = instructions if instructions

--- a/lib/langchain/assistant/llm/adapters/mistral_ai.rb
+++ b/lib/langchain/assistant/llm/adapters/mistral_ai.rb
@@ -18,7 +18,8 @@ module Langchain
             instructions:,
             tools:,
             tool_choice:,
-            parallel_tool_calls:
+            parallel_tool_calls:,
+            metadata: nil
           )
             Langchain.logger.warn "WARNING: `parallel_tool_calls:` is not supported by Mistral AI currently"
 

--- a/lib/langchain/assistant/llm/adapters/openai.rb
+++ b/lib/langchain/assistant/llm/adapters/openai.rb
@@ -18,9 +18,10 @@ module Langchain
             instructions:,
             tools:,
             tool_choice:,
-            parallel_tool_calls:
+            parallel_tool_calls:,
+            metadata:
           )
-            params = {messages: messages}
+            params = {messages: messages, metadata: metadata}
             if tools.any?
               params[:tools] = build_tools(tools)
               params[:tool_choice] = build_tool_choice(tool_choice)

--- a/lib/langchain/assistant/llm/adapters/openai.rb
+++ b/lib/langchain/assistant/llm/adapters/openai.rb
@@ -19,9 +19,10 @@ module Langchain
             tools:,
             tool_choice:,
             parallel_tool_calls:,
-            metadata:
+            metadata: nil
           )
-            params = {messages: messages, metadata: metadata}
+            params = {messages: messages}
+            params[:metadata] = metadata if metadata
             if tools.any?
               params[:tools] = build_tools(tools)
               params[:tool_choice] = build_tool_choice(tool_choice)

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -118,6 +118,7 @@ module Langchain::LLM
     # @option params [String] :model ID of the model to use
     def chat(params = {}, &block)
       parameters = chat_parameters.to_params(params)
+      parameters[:metadata] = params[:metadata] if params[:metadata]
 
       raise ArgumentError.new("messages argument is required") if Array(parameters[:messages]).empty?
       raise ArgumentError.new("model argument is required") if parameters[:model].to_s.empty?


### PR DESCRIPTION
Helps with PROD-891 by passing metadata to the OpenAI logs. As it is now it might serve our use case but not generalize tp everywhere in the gem.
![Screenshot 2025-04-28 at 11 02 19](https://github.com/user-attachments/assets/cb57a32b-aa1b-4310-a81a-06581328e1ef)
