### PR TITLE
Allow passing `tool_choice: "required"`

### DIFF
--- a/lib/langchain/assistant/llm/adapters/openai.rb
+++ b/lib/langchain/assistant/llm/adapters/openai.rb
@@ -72,7 +72,7 @@ module Langchain
 
           # Get the allowed assistant.tool_choice values for OpenAI
           def allowed_tool_choices
-            ["auto", "none"]
+            ["auto", "none", "required"]
           end
 
           # Get the available tool names for OpenAI
@@ -92,7 +92,7 @@ module Langchain
 
           def build_tool_choice(choice)
             case choice
-            when "auto"
+            when "auto", "required"
               choice
             else
               {"type" => "function", "function" => {"name" => choice}}


### PR DESCRIPTION
This allows for prompts to require tools rather than choosing them. This makes it easier to enforce tool calls.

This is [documented here](https://platform.openai.com/docs/api-reference/responses) but is [not currently](https://github.com/patterns-ai-core/langchainrb/blob/main/lib/langchain/assistant/llm/adapters/openai.rb) a part of the langchain gem.