### PR TITLE
Actually handle API errors

### DIFF
--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -179,6 +179,8 @@ module Langchain::LLM
       raise Langchain::LLM::ApiError.new "OpenAI API error: #{response.dig("error", "message")}" if response&.dig("error")
 
       response
+    rescue Faraday::Error => e
+      raise Langchain::LLM::ApiError.new "OpenAI API error: #{e.response_status} #{e.response_body}"
     end
 
     def response_from_chunks

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -180,7 +180,31 @@ module Langchain::LLM
 
       response
     rescue Faraday::Error => e
-      raise Langchain::LLM::ApiError.new "OpenAI API error: #{e.response_status} #{e.response_body}"
+      raise unless e.response.respond_to?(:dig)
+
+      req_method = e.response.dig(:request, :method)
+      req_url = e.response.dig(:request, :url)
+      req_params = e.response.dig(:request, :params)
+      req_headers = e.response.dig(:request, :headers)
+      req_body = e.response.dig(:request, :body)
+      res_status = e.response[:status]
+      res_headers = e.response[:headers]
+      res_body = e.response[:body]
+
+      raise Langchain::LLM::ApiError.new <<~ERR
+        OpenAI API error: Server responded with #{res_status}
+        --- Request ---
+        #{req_method.upcase} #{req_url} #{req_params}
+        Headers:
+        #{req_headers}
+        Body:
+        #{req_body}
+        --- Response ---
+        Headers:
+        #{res_headers}
+        Body:
+        #{res_body}
+      ERR
     end
 
     def response_from_chunks


### PR DESCRIPTION
the gem that provides the OpenAI client uses faraday's raise_error middleware, which is not caught here. So let's actually do that.