### PR TITLE
Support reasoning_effort for OpenAI

### DIFF
--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -46,7 +46,8 @@ module Langchain::LLM
         n: {default: @defaults[:n]},
         temperature: {default: @defaults[:temperature]},
         user: {},
-        response_format: {default: @defaults[:response_format]}
+        response_format: {default: @defaults[:response_format]},
+        reasoning_effort: {default: @defaults[:reasoning_effort]}
       )
       chat_parameters.ignore(:top_k)
     end


### PR DESCRIPTION
This pull request adds support for a new parameter, `reasoning_effort`, to the initialization of the OpenAI LLM client. This allows users to specify the desired level of reasoning effort when making API calls.

OpenAI LLM client parameter updates:

* Added `reasoning_effort` as a configurable parameter in the `initialize` method of `lib/langchain/llm/openai.rb`, allowing users to set its default value.